### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-TimerOne                       KEYWORD1
+TimerOne	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-initialize                     KEYWORD2
-start                          KEYWORD2
-stop                           KEYWORD2
-restart                        KEYWORD2
-resume                         KEYWORD2
-read                           KEYWORD2
-pwm                            KEYWORD2
-disablePwm                     KEYWORD2
-attachInterrupt                KEYWORD2
-detachInterrupt                KEYWORD2
-setPeriod                      KEYWORD2
-setPwmDuty                     KEYWORD2
+initialize	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+restart	KEYWORD2
+resume	KEYWORD2
+read	KEYWORD2
+pwm	KEYWORD2
+disablePwm	KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
+setPeriod	KEYWORD2
+setPwmDuty	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://arduino.github.io/arduino-cli/latest/library-specification/#keywordstxt-format